### PR TITLE
Recover 'Project Wish List' from Defunct Miraheze Wiki Instance

### DIFF
--- a/pages/project-wish-list.mdx
+++ b/pages/project-wish-list.mdx
@@ -1,0 +1,32 @@
+# Project Wish List
+
+## macOS features you love and hate
+
+### We MUST have
+
+ - Swift
+ - Being able to move files in and out of zip files without decompressing and recompressing
+ - Always on top windows
+ - Window snapping
+ - Multiple desktops
+ - Launchpad-like app launcher
+ - use all cores
+ - change the system font
+ - change the menu bar size without needing to change the system resolution first
+ - focus the follow mouse
+ - change my mouse button order
+ - read files from MTP devices
+ - Column View in Filer
+ - "About This Computer" Window with basic Informations about the computer and -&gt; "System Report" Button wicht lists all possible information about the computer.  
+ - Disk Utility
+ - Dashboard
+ - When previewing images, use the arrow keys to jump to the next/previous image.
+ - Activity display
+ - Automator
+ - Network Utility
+ - That during a new installation the own files can be spared from being overwritten.
+
+### Third-Party features it would be NICE to incorporate
+
+ - [Bartender](https://www.macbartender.com/)-level flexibility in menu bar configuration
+ - [Yoink](https://www.yoink.app)-like drag-n-drop shelf


### PR DESCRIPTION
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;This PR recovers the project wish list from the defunct Miraheze wiki instance since it doesn't look like it got copied/migrated over when the wiki moved to being generated as a static site.  (See the commit message for one additional minor detail.)  

Future work:  
 - Do a proofreading/style pass on the file.  
 - See if there's any other (minor?) refactoring that could be done to improve it.  