### PR TITLE
Add Microsoft Surface Laptop Go 2 to the list of tested devices.

### DIFF
--- a/pages/tested.mdx
+++ b/pages/tested.mdx
@@ -35,6 +35,7 @@ This is a list of Virtualization software that has also been tested, and confirm
 
 | Title                                       | Version         | Host                                             | ravynOS Version          | Working                                      | Not working                                   |
 |---------------------------------------------|-----------------|--------------------------------------------------|--------------------------|----------------------------------------------|-----------------------------------------------|
+| UTM                                         | 4.5.3           | macOS Sequoia (Apple M3).                        | 0.5.1                    | Everything via tty so far                    |                                               |
 | VMware Fusion                               | 12.2.1          | macOS Monterey 12.1 (Intel)                      | 0.3.0                    | Everything tested so far                     |                                               |
 | VMware ESXi                                 | 6.0             | Mac mini 2012                                    | 0.3.0                    | Everything tested so far                     |                                               |
 | KVM/qemu                                    | 6.0.0           | Ubuntu 21.10                                     | 0.3.0                    | Everything tested so far                     | no DRM/KMS                                    |

--- a/pages/tested.mdx
+++ b/pages/tested.mdx
@@ -10,6 +10,7 @@ Below is a list of hardware that tested and confirmed to fully/partially work wi
 
 | Vendor and model                            | ravynOS Version | CPU                                              | RAM                      | WiFi                                         | Video                                         |
 |---------------------------------------------|-----------------|--------------------------------------------------|--------------------------|----------------------------------------------|-----------------------------------------------|
+| Microsoft Surface Laptop Go 2               | 0.5.1           | Intel Core i5 (1135G7)                           | 8GB                      | Intel Pro wireless                           | Intel Iris Xe Graphics                        |
 | HP Chromebook 14a Na0023cl                  | 0.4.0pre5       | Intel Celeron n4000                              | 4GB                      | Realtek Wi-Fi 5 (2x2)                        | Intel UHD Graphics 600                        |
 | Lenovo Thinkpad w520                        | 0.4.0pre5       | Intel i7                                         | 16GB                     | Intel Pro wireless                           | Intel HD3000 Graphics                         |
 | Framework 13 Inch                           | 0.4.0pre5       | Intel i5                                         | 32GB                     | Intel Pro wireless                           | Intel Iris Xe Graphics                        |

--- a/pages/tested.mdx
+++ b/pages/tested.mdx
@@ -35,7 +35,7 @@ This is a list of Virtualization software that has also been tested, and confirm
 
 | Title                                       | Version         | Host                                             | ravynOS Version          | Working                                      | Not working                                   |
 |---------------------------------------------|-----------------|--------------------------------------------------|--------------------------|----------------------------------------------|-----------------------------------------------|
-| UTM                                         | 4.5.3           | macOS Sequoia (Apple M3).                        | 0.5.1                    | Everything via tty so far                    |                                               |
+| UTM (emulating x86).                        | 4.5.3           | macOS Sequoia (Apple M3).                        | 0.5.1                    | Everything via tty so far                    |                                               |
 | VMware Fusion                               | 12.2.1          | macOS Monterey 12.1 (Intel)                      | 0.3.0                    | Everything tested so far                     |                                               |
 | VMware ESXi                                 | 6.0             | Mac mini 2012                                    | 0.3.0                    | Everything tested so far                     |                                               |
 | KVM/qemu                                    | 6.0.0           | Ubuntu 21.10                                     | 0.3.0                    | Everything tested so far                     | no DRM/KMS                                    |

--- a/pages/tested.mdx
+++ b/pages/tested.mdx
@@ -35,7 +35,7 @@ This is a list of Virtualization software that has also been tested, and confirm
 
 | Title                                       | Version         | Host                                             | ravynOS Version          | Working                                      | Not working                                   |
 |---------------------------------------------|-----------------|--------------------------------------------------|--------------------------|----------------------------------------------|-----------------------------------------------|
-| UTM (emulating x86).                        | 4.5.3           | macOS Sequoia (Apple M3).                        | 0.5.1                    | Everything via tty so far                    |                                               |
+| UTM (emulating x86)                         | 4.5.3           | macOS Sequoia (Apple M3).                        | 0.5.1                    | Everything via tty so far                    |                                               |
 | VMware Fusion                               | 12.2.1          | macOS Monterey 12.1 (Intel)                      | 0.3.0                    | Everything tested so far                     |                                               |
 | VMware ESXi                                 | 6.0             | Mac mini 2012                                    | 0.3.0                    | Everything tested so far                     |                                               |
 | KVM/qemu                                    | 6.0.0           | Ubuntu 21.10                                     | 0.3.0                    | Everything tested so far                     | no DRM/KMS                                    |


### PR DESCRIPTION
Set up and tested ravynOS v0.5.1 on a Microsoft Surface Laptop Go 2, confirmed (via tty) that all peripherals are detected and work as usual. Have not checked for Bluetooth driver compatibility, but WiFi drivers and all I/O work. 

Added UTM running 0.5.1 (x86) on macOS Sequoia (Apple Silicon) into the list as well. 